### PR TITLE
RDKB-65709: Add support for XER2 platform

### DIFF
--- a/source/OvsAction/ovs_action.c
+++ b/source/OvsAction/ovs_action.c
@@ -140,6 +140,7 @@ static bool is_brcm_wifi_model(int model)
         case OVS_SCXF11BFL_MODEL:
         case OVS_SR213_MODEL:
         case OVS_SCER11BEL_MODEL:
+        case OVS_AYER21BEL_MODEL:
         case OVS_WNXL11BWL_MODEL: 
             return true;
         default:
@@ -242,6 +243,11 @@ static bool SetModelNum(const char * model_num, ovs_action_config * config)
     else if (strcmp(model_num, "SCXF11BFL") == 0)
     {
         config->modelNum = OVS_SCXF11BFL_MODEL;
+        rtn = true;
+    }
+    else if (strcmp(model_num, "AYER21BEL") == 0)
+    {
+        config->modelNum = OVS_AYER21BEL_MODEL;
         rtn = true;
     }
     else

--- a/source/include/OvsDataTypes.h
+++ b/source/include/OvsDataTypes.h
@@ -131,7 +131,8 @@ typedef enum ovs_device_model
   OVS_CGA4332COM_MODEL, /** Technicolor CBR2. vinoth */
   OVS_SCER11BEL_MODEL,  /** Sercomm XER10 */
   OVS_RPI_MODEL,        /** RPI Reference Platform */
-  OVS_SCXF11BFL_MODEL   /** Sercomm XF10 */
+  OVS_SCXF11BFL_MODEL,  /** Sercomm XF10 */
+  OVS_AYER21BEL_MODEL   /** Arcadyan XER2 */
 } OVS_DEVICE_MODEL;
 
 #endif /* OVS_DATA_TYPES_H_ */


### PR DESCRIPTION
Reason for change: Add new XER2 AYER21BEL platform support

Test Procedure: Build should work
Priority:P1
Risks:Low