### PR TITLE
XER10-3142 : Skip adding eth0(WAN) to brlan0 only for XLE warehouse mode

### DIFF
--- a/source/OvsAction/ovs_action.c
+++ b/source/OvsAction/ovs_action.c
@@ -1091,9 +1091,11 @@ static OVS_STATUS configureParentBridge(Gateway_Config * req, bool ovs_enabled,
         v_secure_system("ifconfig %s %s", req->parent_bridge,(req->if_cmd==OVS_IF_UP_CMD ? "up" : "down"));
 #endif
     }
+    // Special Handling for XLE warehouse mode, skip adding eth0(WAN) to brlan0
     if (strcmp(req->if_name, "eth0") == 0 &&
         strcmp(req->parent_bridge, BRLAN0_ETH_NAME) == 0 &&
-        access("/tmp/warehouse_mode", F_OK) == 0)
+        access("/tmp/warehouse_mode", F_OK) == 0 &&
+        (g_ovsActionConfig.modelNum == OVS_WNXL11BWL_MODEL))
     {
         OvsActionInfo("%s: In warehouse mode, skipping port %s addition to bridge %s\n",
                         __func__, req->if_name, req->parent_bridge);


### PR DESCRIPTION
Reason for change: XER10 WH mode 10G port not getting IP since eth0 interface removed from brlan0
Test Procedure:
1) XLE and XER10 warehouse mode should work as expected.

Risks: Low
Priority: P0

Signed-off-by: Santhosh_GujulvaJagadeesh@comcast.com